### PR TITLE
fix(chat): 絵文字スタンプが大きくなりすぎる問題の修正

### DIFF
--- a/packages/frontend/src/pages/messaging/messaging-room.message.vue
+++ b/packages/frontend/src/pages/messaging/messaging-room.message.vue
@@ -440,6 +440,10 @@ async function onPointerup(ev: PointerEvent): Promise<void> {
                     max-width: 100%;
                     max-height: 370px;
                     object-fit: contain;
+
+                    @media (min-width: 500px) {
+                      max-width: 370px;
+                    }
                   }
                 }
               }
@@ -508,6 +512,10 @@ async function onPointerup(ev: PointerEvent): Promise<void> {
                     max-width: 100%;
                     max-height: 370px;
                     object-fit: contain;
+
+                    @media (min-width: 500px) {
+                      max-width: 370px;
+                    }
                   }
                 }
               }


### PR DESCRIPTION
## What
スタンプをちいさくする

## Why
PC環境でスタンプが大きくなる
